### PR TITLE
Improve cross-platform compatibility for Euroc dataset file reading

### DIFF
--- a/xrslam-pc/player/src/IO/euroc_dataset_reader.h
+++ b/xrslam-pc/player/src/IO/euroc_dataset_reader.h
@@ -37,13 +37,22 @@ struct CameraCsv {
         items.clear();
         if (FILE *csv = fopen(filename.c_str(), "r")) {
             char header_line[2048];
-            int ret = fscanf(csv, "%2047[^\r]\r\n", header_line);
+            #ifdef _WIN32
+                int ret = fscanf(csv, "%2047[^\r]\r\n", header_line);
+            #else
+                int ret = fscanf(csv, "%2047[^\n]\n", header_line);
+            #endif
             char filename_buffer[2048];
             CameraData item;
             while (!feof(csv)) {
                 memset(filename_buffer, 0, 2048);
+            #ifdef _WIN32
                 if (fscanf(csv, "%lf,%2047[^\r]\r\n", &item.t,
                            filename_buffer) != 2) {
+            #else
+                if (fscanf(csv, "%lf,%2047[^\n]\n", &item.t,
+                           filename_buffer) != 2) {
+            #endif
                     break;
                 }
                 item.t *= 1e-9;
@@ -87,12 +96,23 @@ struct ImuCsv {
         items.clear();
         if (FILE *csv = fopen(filename.c_str(), "r")) {
             char header_line[2048];
-            int ret = fscanf(csv, "%2047[^\r]\r\n", header_line);
+            #ifdef _WIN32
+                int ret = fscanf(csv, "%2047[^\r]\r\n", header_line);
+            #else
+                int ret = fscanf(csv, "%2047[^\n]\n", header_line);
+            #endif
             ImuData item;
-            while (!feof(csv) &&
-                   fscanf(csv, "%lf,%lf,%lf,%lf,%lf,%lf,%lf\r\n", &item.t,
-                          &item.w.x, &item.w.y, &item.w.z, &item.a.x, &item.a.y,
-                          &item.a.z) == 7) {
+            #ifdef _WIN32
+                while (!feof(csv) &&
+                       fscanf(csv, "%lf,%lf,%lf,%lf,%lf,%lf,%lf\r\n", &item.t,
+                              &item.w.x, &item.w.y, &item.w.z, &item.a.x,
+                              &item.a.y, &item.a.z) == 7) {
+            #else
+                while (!feof(csv) &&
+                       fscanf(csv, "%lf,%lf,%lf,%lf,%lf,%lf,%lf\n", &item.t,
+                              &item.w.x, &item.w.y, &item.w.z, &item.a.x,
+                              &item.a.y, &item.a.z) == 7) {
+            #endif
                 item.t *= 1e-9;
                 items.emplace_back(std::move(item));
             }


### PR DESCRIPTION
This PR addresses a cross-platform compatibility issue in the dataset file reading logic. The previous implementation used '\r\n' format specifiers for fscanf based on the platform, which could lead to incorrect results on non-Windows systems.

**Changes:**

Conditional compilation: The code now uses #ifdef _WIN32 to conditionally compile the fscanf format specifier based on the platform.
Windows-specific format: For Windows platforms, the format specifier %2047[^\r]\r\n is used, which matches up to 2047 non-carriage return characters followed by a carriage return and newline sequence.
Linux-specific format: For non-Windows platforms, the format specifier %2047[^\n]\n is used, which matches up to 2047 non-newline characters followed by a newline character.
**Benefits:**

Improved cross-platform compatibility: The code now works correctly on both Windows and Linux systems.
Enhanced robustness: The code is less likely to fail due to platform-specific differences in newline characters.
**Testing:**

Tested on Ubuntu 20.04 LTS 

By making this change, we can ensure that our code can handle dataset file correctly on a wider range of platforms.

JasonG