### PR TITLE
Fix iOS virtual object drift and iOS build on latest iOS 26.1 + Xcode 26.1

### DIFF
--- a/build-ios.sh
+++ b/build-ios.sh
@@ -28,6 +28,7 @@ cmake -S . -B build/iOS                                                 \
     -D ENABLE_BITCODE=0                                                 \
     -D ENABLE_ARC=1                                                     \
     -D ENABLE_VISIBILITY=0                                              \
+    -D CMAKE_POLICY_VERSION_MINIMUM=3.5                                 \
     -D APP_IDENTIFIER_PREFIX="${APP_IDENTIFIER_PREFIX}"                 \
     -D IOS_DEVELOPMENT_TEAM="${IOS_DEVELOPMENT_TEAM}"
 

--- a/cmake/depends/yaml-cpp.cmake
+++ b/cmake/depends/yaml-cpp.cmake
@@ -5,7 +5,7 @@ if(NOT TARGET depends::yaml-cpp)
   FetchContent_Declare(
     depends-yaml-cpp
     GIT_REPOSITORY https://github.com/jbeder/yaml-cpp.git
-    GIT_TAG        yaml-cpp-0.6.2
+    GIT_TAG        yaml-cpp-0.7.0
   )
   FetchContent_GetProperties(depends-yaml-cpp)
   if(NOT depends-yaml-cpp_POPULATED)

--- a/xrslam-ios/visualizer/configs/iPhone 16e.yaml
+++ b/xrslam-ios/visualizer/configs/iPhone 16e.yaml
@@ -1,0 +1,52 @@
+%YAML:1.0
+imu:
+  # inertial sensor noise model parameters (static)
+  gyroscope_noise_density: 4.e-8       # [ rad / s / sqrt(Hz) ]
+  gyroscope_random_walk: 1.0e-10       # [ rad / s^2 / sqrt(Hz) ]
+  accelerometer_noise_density: 4.e-6    # [ m / s^2 / sqrt(Hz) ]
+  accelerometer_random_walk: 1.0e-8    # [ m / s^3 / sqrt(Hz) ]
+  accelerometer_bias: [0.0, 0.0, 0.0] # acc bias prior
+  gyroscope_bias: [0.0, 0.0, 0.0]     # gyro bias prior
+  extrinsic:
+    q_bi: [ 0.0, 0.0, 0.0, 1.0 ] # x y z w
+    p_bi: [ 0.0, 0.0, 0.0 ] # x y z [m]
+  noise:
+    cov_g: [
+      2.8791302399999997e-08, 0.0, 0.0,
+      0.0, 2.8791302399999997e-08, 0.0,
+      0.0, 0.0, 2.8791302399999997e-08]
+    cov_a: [
+      4.0e-6, 0.0, 0.0,
+      0.0, 4.0e-6, 0.0,
+      0.0, 0.0, 4.0e-6]
+    cov_bg: [
+      3.7608844899999997e-10, 0.0, 0.0,
+      0.0, 3.7608844899999997e-10, 0.0,
+      0.0, 0.0, 3.7608844899999997e-10]
+    cov_ba: [
+      9.0e-6, 0.0, 0.0,
+      0.0, 9.0e-6, 0.0,
+      0.0, 0.0, 9.0e-6]
+cam0:
+  # camera0 wrt. body frame
+  T_BS:
+    cols: 4
+    rows: 4
+    data: [0.0, -1.0, 0.0, 0.03290364,
+           -1.0, 0.0, 0.0, -0.00696553,
+           0.0, 0.0, -1.0,-0.00286231,
+           0.0, 0.0, 0.0, 1.0]
+  resolution: [640, 480]        # resolution of camera
+  camera_model: pinhole         # camera model
+  distortion_model: radtan      # distortion model
+  intrinsics: [448.96781816245402, 449.14399528627763, 321.34605334072404, 240.71641804985396] # fu, fv, cu, cv
+  camera_distortion_flag: 0     # use distortion model or not
+  distortion: [0.0, 0.0, 0.0, 0.0] # k1, k2, p1, p2, xi
+  camera_readout_time: 0.0      # camera readout time
+  time_offset: 0.0              # camera time delay wrt. IMU
+  extrinsic:
+    q_bc: [-0.7071068, 0.7071068, 0, 0] # x y z w
+    p_bc: [0.03290364, -0.00696553, -0.00286231] # x y z [m]
+  noise: [
+    0.5, 0.0,
+    0.0, 0.5] # [pixel^2]

--- a/xrslam-ios/visualizer/configs/slam_params.yaml
+++ b/xrslam-ios/visualizer/configs/slam_params.yaml
@@ -1,7 +1,7 @@
 %YAML:1.0
 output:
-  q_bo: [ -0.7071068, 0.7071068, 0, 0 ] # x y z w
-  p_bo: [ 0.053617261855615515, -0.0016905232538204646, -0.0075510493739824724 ] # x y z [m]
+  q_bo: [ 0, 0, 0, 1 ] # x y z w
+  p_bo: [ 0, 0, 0 ] # x y z [m]
 
 feature_tracker:
   min_keypoint_distance: 25.0

--- a/xrslam-ios/visualizer/src/UIDevice+Model.swift
+++ b/xrslam-ios/visualizer/src/UIDevice+Model.swift
@@ -85,6 +85,7 @@ public enum Model : String {
     iPhone14Plus       = "iPhone 14 Plus",
     iPhone14Pro        = "iPhone 14 Pro",
     iPhone14ProMax     = "iPhone 14 Pro Max",
+    iPhone16e          = "iPhone 16e",
 
     // Apple Watch
     AppleWatch1         = "Apple Watch 1gen",
@@ -263,6 +264,7 @@ var type: Model {
         "iPhone14,8":  .iPhone14Plus,
         "iPhone15,2":  .iPhone14Pro,
         "iPhone15,3":  .iPhone14ProMax,
+        "iPhone17,5":  .iPhone16e,
 
         // Apple Watch
         "Watch1,1" : .AppleWatch1,

--- a/xrslam-ios/visualizer/src/XRSLAM_iOS.mm
+++ b/xrslam-ios/visualizer/src/XRSLAM_iOS.mm
@@ -137,11 +137,11 @@ struct OutputState {
 
     cv::Mat raw_image = cv::Mat(h, w, CV_8UC4, baseAddress, pixelPerRow);
 
-    CVPixelBufferUnlockBaseAddress(pixelBuffer, 0);
-
     cv::Mat rgb_image;
     cv::cvtColor(raw_image, cvimage, cv::COLOR_BGRA2GRAY);
     cv::cvtColor(raw_image, rgb_image, cv::COLOR_BGRA2RGB);
+
+    CVPixelBufferUnlockBaseAddress(pixelBuffer, 0);
 
     uiimage = MatToUIImage(rgb_image);
 }
@@ -157,6 +157,7 @@ struct OutputState {
         image.timeStamp = t;
         image.data = cvimage.data;
         image.stride = cvimage.step[0];
+        image.channel = cvimage.channels();
         XRSLAMPushSensorData(XRSLAM_SENSOR_CAMERA, &image);
         XRSLAMRunOneFrame();
 

--- a/xrslam/src/xrslam/map/frame.h
+++ b/xrslam/src/xrslam/map/frame.h
@@ -14,7 +14,7 @@ class Track;
 class Map;
 class ReprojectionErrorFactor;
 
-enum FrameTag {
+enum FrameTag : int {
     FT_KEYFRAME = 0,
     FT_NO_TRANSLATION,
     FT_FIX_POSE,

--- a/xrslam/src/xrslam/map/track.h
+++ b/xrslam/src/xrslam/map/track.h
@@ -10,7 +10,7 @@
 
 namespace xrslam {
 
-enum TrackTag {
+enum TrackTag : int {
     TT_VALID = 0,
     TT_TRIANGULATED,
     TT_FIX_INVD,


### PR DESCRIPTION
Fix #63 
- bump up yaml-cpp to fix cmake complain
- add sensor config for iPhone 16e
- **Fix iOS virtual object drift by aligning output/camera extrinsic conventions**. See summary below.

Summary
This PR fixes an iOS visualizer regression where newly placed virtual objects appear to drift in the opposite direction of camera motion. The issue was caused by a coordinate-frame convention mismatch introduced after commit 632b72d (commit 632b72d known-good on iOS as stated by maintainer https://github.com/openxrlab/xrslam/issues/63#issuecomment-3262325327). 

User-visible Symptoms
 - After tapping to place a virtual object, the object “slides” opposite to device motion (camera translation), as if the world is moving backwards.
 - Tracking otherwise appears to run, but AR overlay is unstable/inverted.

Root Cause
Between 632b72d and current main, the meaning of XRSLAM_RESULT_CAMERA_POSE changed:
- In 632b72d, XRSLAM_RESULT_CAMERA_POSE returned the raw output pose from detail_->get_latest_pose() (no additional extrinsic composition).
- In current main, `XRSLAM_RESULT_CAMERA_POSE` composes the pose with camera_to_body_rotation/translation (xrslam-interface/src/XRSLAMManager.cpp:168).

On iOS, `xrslam-ios/visualizer/configs/slam_params.yaml` had `output.q_bo`/`p_bo` set to the camera extrinsic (historically used to make the raw output pose in body frame align with the camera frame). With the newer `XRSLAM_RESULT_CAMERA_POSE` additionally applying camera extrinsics, the camera extrinsic effectively gets applied twice. This double application causes the SceneKit camera/world transform mapping to behave as if translation is inverted, producing the opposite-direction drift.

Fix
  - Make iOS SLAM output frame neutral again by setting output.q_bo to identity and output.p_bo to **zero** in
    xrslam-ios/visualizer/configs/slam_params.yaml, so the camera extrinsic is applied exactly once (by
    `XRSLAM_RESULT_CAMERA_POSE`).
- Other changes that are necessary to make the library compilable by the latest Xcode and iOS


Notes / Compatibility
- This restores behavior consistent with 632b72d for the iOS visualizer while keeping the newer core convention where `XRSLAM_RESULT_CAMERA_POSE` includes camera-to-body extrinsics.
- If other apps rely on `output.q_bo`/`p_bo` to bake in camera extrinsics, they should not also use `XRSLAM_RESULT_CAMERA_POSE` that applies extrinsics.

 How to Test

  1. Build/run the iOS visualizer.
  2. Start tracking and tap to place a cube.
  3. Move the device laterally/forward-back: the cube should remain stable in world space.